### PR TITLE
Minor fixes

### DIFF
--- a/src-bd/classes/VideoManager.ts
+++ b/src-bd/classes/VideoManager.ts
@@ -5,7 +5,7 @@ import {CaptureEvent} from "../../src-tauri/bindings/CaptureEvent";
 import {ICEEvent} from "../../src-tauri/bindings/ICEEvent";
 import {AnswerOfferEvent} from "../../src-tauri/bindings/AnswerOfferEvent";
 import DiscordSourcePlugin from "../index";
-import { UpdateUserInfoEvent } from "../../src-tauri/bindings/UpdateUserInfoEvent";
+import {UpdateUserInfoEvent} from "../../src-tauri/bindings/UpdateUserInfoEvent";
 
 interface DiscordStream {
     canvas?: HTMLCanvasElement;
@@ -145,12 +145,14 @@ export class VideoManager {
             return;
         }
 
+        this.streams.delete(streamId);
+
         this.ws.sendEvent({
             type: "remove",
             detail: {
                 streamId
             }
-        })
+        });
     }
 
     public async stop() {

--- a/src-bd/classes/VideoManager.ts
+++ b/src-bd/classes/VideoManager.ts
@@ -26,7 +26,10 @@ export class VideoManager {
         this.ws.addEventListener("ice", (e) => this.onIceCandidateEvent(e));
 
         //TODO: Make this configurable in settings
-        this.updateInfoInterval = setInterval(()=>{
+        this.updateInfoInterval = setInterval(() => {
+            if (this.streams.size === 0) {
+                return;
+            }
             this.updateInfo(Array.from(this.streams.keys()));
         }, 60000) as any as number;
     }

--- a/src-bd/classes/WS.ts
+++ b/src-bd/classes/WS.ts
@@ -1,5 +1,5 @@
-import { TypedEventTarget } from 'typescript-event-target';
-import { MessageType } from "../../src-tauri/bindings/MessageType";
+import {TypedEventTarget} from 'typescript-event-target';
+import {MessageType} from "../../src-tauri/bindings/MessageType";
 import {Utils} from "./Utils";
 import {MessageEventMap} from "../../shared/MappedMessageType";
 
@@ -12,11 +12,12 @@ export class WS extends TypedEventTarget<MessageEventMap> {
         super();
         this.port = port;
     }
+
     /**
      * Wait for the websocket to connect
      */
     public async connect(): Promise<boolean> {
-        if(this.isClosed) return false;
+        if (this.isClosed) return false;
 
         this.ws = new WebSocket(`ws://localhost:${this.port}/discord`);
 
@@ -32,15 +33,16 @@ export class WS extends TypedEventTarget<MessageEventMap> {
             });
         }) as boolean;
 
-        if(connectionState) {
+        if (connectionState) {
             this.ws.addEventListener("message", (e) => this.eventHandler(e));
 
-            this.ws.addEventListener("close", ()=>{
-                Utils.log("Connection to Discord Source lost, retrying...");
+            this.ws.addEventListener("close", () => {
+                if (this.isClosed) return;
 
+                Utils.log("Connection to Discord Source lost, retrying...");
                 this.connect();
             })
-        }else{
+        } else {
             return this.connect();
         }
 

--- a/src-bd/index.ts
+++ b/src-bd/index.ts
@@ -19,7 +19,7 @@ export default class DiscordSourcePlugin {
                 onConfirm: () => {
                     window.open("https://github.com/Dreaming-Codes/discord-source");
                 },
-            })
+            });
 
             BdApi.Plugins.disable(DiscordSourcePlugin.name);
             return;
@@ -32,18 +32,19 @@ export default class DiscordSourcePlugin {
         DiscordSourcePlugin.videoManager = new VideoManager(ws);
 
         BdApi.Patcher.after(DiscordSourcePlugin.name, DiscordSourcePlugin.VideoHandler, "_handleVideoStreamId", (_, [streamData]: [StreamData]) => {
-            if(streamData.streamId) {
+            if (streamData.streamId) {
                 DiscordSourcePlugin.videoManager.newVideoStream(streamData.streamId, streamData.userId);
-            }else{
+            } else {
                 DiscordSourcePlugin.videoManager.removeVideoStream(streamData.userId);
             }
         });
 
         Utils.log("Plugin started");
     }
+
     stop() {
         BdApi.Patcher.unpatchAll(DiscordSourcePlugin.name);
-        DiscordSourcePlugin.videoManager.stop();
+        if (DiscordSourcePlugin.videoManager) DiscordSourcePlugin.videoManager.stop();
         Utils.log("Plugin stopped");
     }
 }

--- a/src-bd/index.ts
+++ b/src-bd/index.ts
@@ -44,7 +44,7 @@ export default class DiscordSourcePlugin {
 
     stop() {
         BdApi.Patcher.unpatchAll(DiscordSourcePlugin.name);
-        if (DiscordSourcePlugin.videoManager) DiscordSourcePlugin.videoManager.stop();
+        DiscordSourcePlugin.videoManager?.stop();
         Utils.log("Plugin stopped");
     }
 }


### PR DESCRIPTION
- Fix plugin stop method failing when videoManager is not initialized
- Do not send stream info updates if no streams are detected
- Fix streams not being removed from videoManager
- Do not print "reconnecting" message when the plugin is being disabled