### PR TITLE
fix: kill discord after plugin update

### DIFF
--- a/src-tauri/src/bd.rs
+++ b/src-tauri/src/bd.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{error, info};
 
 use crate::DEFAULT_WS_PORT;
+use crate::ds_installer::kill_discord;
 
 const PLUGIN: &str = include_str!("../../dist-bd/DiscordSourcePlugin.plugin.js");
 
@@ -61,7 +62,11 @@ pub async fn install_plugin(path: String) -> bool {
         return false;
     }
 
-    false
+    kill_discord();
+
+    info!("Plugin updated");
+
+    true
 }
 
 #[tauri::command]

--- a/src-tauri/src/ds_installer.rs
+++ b/src-tauri/src/ds_installer.rs
@@ -99,7 +99,7 @@ fn is_discord(cmdline: &str) -> bool {
     DISCORD_EXE_NAMES.iter().any(|exe_name| !cmdline.to_lowercase().contains("discord-source") && cmdline.to_lowercase().contains(exe_name))
 }
 
-fn kill_discord() {
+pub fn kill_discord() {
     info!("Killing Discord");
 
     let processes = SYS.processes();


### PR DESCRIPTION
This prevents unclosed ws connections after update